### PR TITLE
package name no longer in repo

### DIFF
--- a/inst/packages.txt
+++ b/inst/packages.txt
@@ -71,7 +71,7 @@ libglib-2.0-dev
 libgmp3
 libgnutls-dev
 libgnutls-extra26
-libgnutlsxx26
+libgnutlsxx27
 libgpg-error-dev
 libgpod
 libgpsbt-dev


### PR DESCRIPTION
openpandora repo (http://openpandora.org/feeds/unstable/armv7a/) has different package name than in list.